### PR TITLE
Remove require 'pry' from resource_array.rb

### DIFF
--- a/lib/hello_sign/resource/resource_array.rb
+++ b/lib/hello_sign/resource/resource_array.rb
@@ -1,4 +1,3 @@
-require 'pry'
 module HelloSign
   module Resource
 


### PR DESCRIPTION
Pry should only be required in development environments and the require here breaks production.
