### PR TITLE
Use correct respond_to? signature

### DIFF
--- a/lib/hello_sign.rb
+++ b/lib/hello_sign.rb
@@ -20,7 +20,7 @@ module HelloSign
   # If HelloSign module don't respond_to? method, ask HelloSign::Client whether it respond or not
   # @param  method [Symbol] method name
   #
-  def self.respond_to?(method)
+  def self.respond_to?(method, include_all=false)
     return super || client.respond_to?(method)
   end
 


### PR DESCRIPTION
respond_to? takes an optional include_all false: http://ruby-doc.org/core-2.1.3/Object.html#method-i-respond_to-3F

This fixes hellosign's ruby sdk so you can set expectations against methods on the HelloSign module.
