### PR TITLE
Add support for using a proxy when connecting to API

### DIFF
--- a/lib/hello_sign/client.rb
+++ b/lib/hello_sign/client.rb
@@ -51,7 +51,7 @@ module HelloSign
     include Api::OAuth
     include Api::ApiApp
 
-    attr_accessor :end_point, :oauth_end_point, :api_version, :user_agent, :client_id, :client_secret, :email_address, :password, :api_key, :auth_token, :logging, :log_level
+    attr_accessor :end_point, :oauth_end_point, :api_version, :user_agent, :client_id, :client_secret, :email_address, :password, :api_key, :auth_token, :logging, :log_level, :proxy_uri, :proxy_user, :proxy_pass
 
     ERRORS = {
       400 => Error::BadRequest,
@@ -162,6 +162,13 @@ module HelloSign
       elsif email_address
         connection.basic_auth email_address, password
       else
+      end
+      if proxy_uri
+        connection.options.proxy = {
+          :uri      => proxy_uri,
+          :user     => proxy_user,
+          :password => proxy_pass
+        }
       end
       connection
     end

--- a/lib/hello_sign/configuration.rb
+++ b/lib/hello_sign/configuration.rb
@@ -33,7 +33,7 @@ module HelloSign
     DEFAULT_ENDPOINT = 'https://api.hellosign.com'
     DEFAULT_API_VERSION = '/v3'
     DEFAULT_OAUTH_ENDPOINT = 'https://www.hellosign.com'
-    VALID_OPTIONS_KEYS = [:end_point, :oauth_end_point, :api_version, :user_agent, :client_id, :client_secret, :email_address, :password, :api_key, :auth_token, :log_level, :logging]
+    VALID_OPTIONS_KEYS = [:end_point, :oauth_end_point, :api_version, :user_agent, :client_id, :client_secret, :email_address, :password, :api_key, :auth_token, :log_level, :logging, :proxy_uri, :proxy_user, :proxy_pass]
 
 
     DEFAULT_USER_AGENT = "hellosign-ruby-sdk/" + HelloSign::VERSION
@@ -74,6 +74,9 @@ module HelloSign
       self.user_agent = DEFAULT_USER_AGENT
       self.log_level = 3
       self.logging = true
+      self.proxy_uri = nil
+      self.proxy_user = nil
+      self.proxy_pass = nil
     end
   end
 end

--- a/spec/hello_sign/client_spec.rb
+++ b/spec/hello_sign/client_spec.rb
@@ -25,7 +25,10 @@ describe HelloSign::Client do
           :client_secret => 'client_secret',
           :auth_token => 'auth_token',
           :log_level => 5,
-          :logging => false
+          :logging => false,
+          :proxy_uri => 'proxy_uri',
+          :proxy_user => 'proxy_user',
+          :proxy_pass => 'proxy_pass'
         }
       }
       subject(:client) { HelloSign::Client.new custom_client }


### PR DESCRIPTION
Add new config options `proxy_uri`, `proxy_user`, and `proxy_pass`
that will be passed to Faraday so that outgoing requests to the
API endpoints will use the configured proxy settings.

Fixes #18.
