### PR TITLE
wrap proxy_uri in URI

### DIFF
--- a/lib/hello_sign/client.rb
+++ b/lib/hello_sign/client.rb
@@ -165,7 +165,7 @@ module HelloSign
       end
       if proxy_uri
         connection.options.proxy = {
-          :uri      => URI(proxy_uri),
+          :uri      => proxy_uri.nil? ? nil : URI(proxy_uri),
           :user     => proxy_user,
           :password => proxy_pass
         }

--- a/lib/hello_sign/client.rb
+++ b/lib/hello_sign/client.rb
@@ -165,7 +165,7 @@ module HelloSign
       end
       if proxy_uri
         connection.options.proxy = {
-          :uri      => proxy_uri,
+          :uri      => URI(proxy_uri),
           :user     => proxy_user,
           :password => proxy_pass
         }


### PR DESCRIPTION
This is just a small improvement over @reedloden's changes, that I think makes it slightly easier to configure a proxy.

Without this change, it's fairly easy to trigger the error

```
NoMethodError: undefined method `host' for "https://example.com:1337":String
```

which can be a bit annoying to debug.

(It's worth noting that the wrapping is idempotent; `URI(URI(x))` is the same as `URI(x)`)

Please let me know what you think!
