### PR TITLE
don't treat text responses as json

### DIFF
--- a/lib/hello_sign/client.rb
+++ b/lib/hello_sign/client.rb
@@ -185,8 +185,10 @@ module HelloSign
         response.body
       elsif response.body.strip.empty?
         {}
-      else
+      elsif response['content-type'] == 'application/json'
         MultiJson.load response.body.strip
+      else
+        response.body
       end
     end
 


### PR DESCRIPTION
this codifies the fixes presented in #20 and https://github.com/HelloFax/hellosign-ruby-sdk/issues/22

over the last day, we started seeing a `MultiJson::ParseError` on pdf downloads, and after digging around a bit found the issues above as references.
