### PR TITLE
Fix for failing #signature_request_files when format is 'zip'

### DIFF
--- a/lib/hello_sign/client.rb
+++ b/lib/hello_sign/client.rb
@@ -183,6 +183,8 @@ module HelloSign
     def parse(response)
       if response['content-type'] == 'application/pdf'
         response.body
+      elsif response['content-type'] == 'application/zip'
+        response.body
       elsif response.body.strip.empty?
         {}
       else


### PR DESCRIPTION
We request signed files as zips and the gem recently began failing. This patch avoids attempting to parse zip payloads as JSON and returns the raw response.body for responses with a content-type of application/zip.
