### PR TITLE
fix listing signature requests

### DIFF
--- a/lib/hello_sign/api/signature_request.rb
+++ b/lib/hello_sign/api/signature_request.rb
@@ -64,7 +64,7 @@ module HelloSign
       #
       def get_signature_requests(opts={})
         path = '/signature_request/list'
-        opts[:query] = create_search_string(opts[:query])
+        opts[:query] = create_search_string(opts[:query]) if opts[:query]
         query = create_query_string(opts, [:page, :page_size, :ux_version, :query])
         path += query
         HelloSign::Resource::ResourceArray.new get(path, opts), 'signature_requests',  HelloSign::Resource::SignatureRequest


### PR DESCRIPTION
the tests were actually broken:

```
Failures:

  1) HelloSign::Api::SignatureRequest#get_signature_requests each of Array is an SignatureRequest
     Failure/Error: raw_string.tr(" ", "+")

     NoMethodError:
       undefined method `tr' for nil:NilClass
     # ./lib/hello_sign/client.rb:275:in `create_search_string'
     # ./lib/hello_sign/api/signature_request.rb:67:in `get_signature_requests'
     # ./lib/hello_sign.rb:40:in `method_missing'
     # ./spec/hello_sign/api/signature_request_spec.rb:22:in `block (3 levels) in <top (required)>'

  2) HelloSign::Api::SignatureRequest#get_signature_requests should return a SignatureRequestArray
     Failure/Error: raw_string.tr(" ", "+")

     NoMethodError:
       undefined method `tr' for nil:NilClass
     # ./lib/hello_sign/client.rb:275:in `create_search_string'
     # ./lib/hello_sign/api/signature_request.rb:67:in `get_signature_requests'
     # ./lib/hello_sign.rb:40:in `method_missing'
     # ./spec/hello_sign/api/signature_request_spec.rb:22:in `block (3 levels) in <top (required)>'

  3) HelloSign::Api::SignatureRequest#get_signature_requests should get the correct resource
     Failure/Error: raw_string.tr(" ", "+")

     NoMethodError:
       undefined method `tr' for nil:NilClass
     # ./lib/hello_sign/client.rb:275:in `create_search_string'
     # ./lib/hello_sign/api/signature_request.rb:67:in `get_signature_requests'
     # ./lib/hello_sign.rb:40:in `method_missing'
     # ./spec/hello_sign/api/signature_request_spec.rb:22:in `block (3 levels) in <top (required)>'

Finished in 1.19 seconds (files took 0.89168 seconds to load)
140 examples, 3 failures

Failed examples:

rspec ./spec/hello_sign/api/signature_request_spec.rb:33 # HelloSign::Api::SignatureRequest#get_signature_requests each of Array is an SignatureRequest
rspec ./spec/hello_sign/api/signature_request_spec.rb:29 # HelloSign::Api::SignatureRequest#get_signature_requests should return a SignatureRequestArray
rspec ./spec/hello_sign/api/signature_request_spec.rb:25 # HelloSign::Api::SignatureRequest#get_signature_requests should get the correct resource
```
