### PR TITLE
Change method for embedded template edit url from GET to POST to support merge fields

### DIFF
--- a/lib/hello_sign/api/embedded.rb
+++ b/lib/hello_sign/api/embedded.rb
@@ -61,6 +61,8 @@ module HelloSign
         defaults = { :skip_signer_roles => 0, :skip_subject_message => 0, :test_mode => 0 }
         opts = defaults.merge(opts)
 
+        prepare_merge_fields opts
+
         HelloSign::Resource::Embedded.new post("/embedded/edit_url/#{opts[:template_id]}", :body => opts)
       end
     end

--- a/lib/hello_sign/api/embedded.rb
+++ b/lib/hello_sign/api/embedded.rb
@@ -51,6 +51,7 @@ module HelloSign
       # @option opts [String] template_id The id of the template to get a edit url for
       # @option opts [Integer] skip_signer_roles Whether editing signer roles should be skipped
       # @option opts [Integer] skip_subject_message Whether editing subject/message should be skipped
+      # @option opts [Array<Hash>] merge_fields Merge fields that can be placed in the template
       #
       # @return [HelloSign::Resource::Embedded] Returns an Embedded object
       # @example
@@ -60,7 +61,7 @@ module HelloSign
         defaults = { :skip_signer_roles => 0, :skip_subject_message => 0, :test_mode => 0 }
         opts = defaults.merge(opts)
 
-        HelloSign::Resource::Embedded.new get("/embedded/edit_url/#{opts[:template_id]}?skip_signer_roles=#{opts[:skip_signer_roles]}&skip_subject_message=#{opts[:skip_subject_message]}&test_mode=#{opts[:test_mode]}")
+        HelloSign::Resource::Embedded.new post("/embedded/edit_url/#{opts[:template_id]}", :body => opts)
       end
     end
   end

--- a/lib/hello_sign/client.rb
+++ b/lib/hello_sign/client.rb
@@ -287,10 +287,6 @@ module HelloSign
       prepare opts, :template_ids
     end
 
-    def prepare_cc_roles(opts)
-      prepare opts, :merge_fields
-    end
-
     def prepare_signer_roles(opts)
       prepare opts, :signer_roles
     end
@@ -298,6 +294,13 @@ module HelloSign
     def prepare_custom_fields(opts)
         if (opts[:custom_fields] and opts[:custom_fields].is_a? Array)
             opts[:custom_fields] = MultiJson.dump(opts[:custom_fields])
+        end
+        #ignore if it's already a string, or not present
+    end
+
+    def prepare_merge_fields(opts)
+        if (opts[:merge_fields] and opts[:merge_fields].is_a? Array)
+            opts[:merge_fields] = MultiJson.dump(opts[:merge_fields])
         end
         #ignore if it's already a string, or not present
     end


### PR DESCRIPTION
In order to pass in merge_fields, embedded template edit url calls must be POST instead of GET.