### PR TITLE
Allow uploading files with update_template_files

### DIFF
--- a/lib/hello_sign/api/template.rb
+++ b/lib/hello_sign/api/template.rb
@@ -174,6 +174,7 @@ module HelloSign
       def update_template_files(opts)
         template_id = opts.delete(:template_id)
         path = "/template/update_files/#{template_id}"
+        prepare_files opts
         HelloSign::Resource::Template.new post(path, :body => opts)
       end
     end


### PR DESCRIPTION
Looks like this was omitted and thus uploading files from the call was not possible before. This worked for me testing on our account with local files.