### PR TITLE
Custom fields

### DIFF
--- a/lib/hello_sign/api/signature_request.rb
+++ b/lib/hello_sign/api/signature_request.rb
@@ -88,6 +88,7 @@ module HelloSign
       #   * :order (Integer) The order the signer is required to sign in
       #   * :pin (Integer) The 4- to 12-character access code that will secure this signer's signature page. You must have a business plan to use this feature.
       # @option opts [Array<String>] cc_email_addresses The email addresses that should be CCed.
+      # @option opts [Array<Hash>] custom_fields An array of custom merge fields, representing those present on the document with Text Tags.
       # @option opts [String] form_fields_per_document
       #
       # @return [HelloSign::Resource::SignatureRequest] a SignatureRequest
@@ -122,6 +123,7 @@ module HelloSign
         prepare_files opts
         prepare_signers opts
         prepare_form_fields opts
+        prepare_custom_fields opts
 
         HelloSign::Resource::SignatureRequest.new post('/signature_request/send', :body => opts)
       end

--- a/lib/hello_sign/api/signature_request.rb
+++ b/lib/hello_sign/api/signature_request.rb
@@ -292,6 +292,7 @@ module HelloSign
       #   * :order (Integer) The order the signer is required to sign in
       #   * :pin (Integer) The 4- to 12-character access code that will secure this signer's signature page. You must have a business plan to use this feature.
       # @option opts [Array<String>] cc_email_addresses The email addresses that should be CCed.
+      # @option opts [Array<Hash>] custom_fields An array of custom merge fields, representing those present on the document with Text Tags.
       # @option opts [String] form_fields_per_document
       # @option opts [Integer] ux_version sets the version of the signer page to use
       #
@@ -327,6 +328,7 @@ module HelloSign
         prepare_files opts
         prepare_signers opts
         prepare_form_fields opts
+        prepare_custom_fields opts
 
         HelloSign::Resource::SignatureRequest.new post('/signature_request/create_embedded', :body => opts)
       end

--- a/lib/hello_sign/api/unclaimed_draft.rb
+++ b/lib/hello_sign/api/unclaimed_draft.rb
@@ -55,6 +55,7 @@ module HelloSign
       #   * :order (Integer) The order the signer is required to sign in (optional)
       #   * :pin (Integer) The 4-digit code that will secure this signer's signature page. You must have a business plan to use this feature. (optional)
       # @option opts [Array<String>] cc_email_addresses The email addresses that should be CCed.
+      # @option opts [Array<Hash>] custom_fields An array of custom merge fields, representing those present on the document with Text Tags.
       # @option opts [String] form_fields_per_document
       #
       # @return [HelloSign::Resource::UnclaimedDraft] a UnclaimedDraft object
@@ -91,6 +92,8 @@ module HelloSign
       def create_unclaimed_draft opts
         prepare_files opts
         prepare_form_fields opts
+        prepare_custom_fields opts
+
         if opts[:type] == 'request_signature'
           prepare_signers opts
         end
@@ -116,6 +119,7 @@ module HelloSign
       #   * :order (Integer) The order the signer is required to sign in (optional)
       #   * :pin (Integer) The 4-digit code that will secure this signer's signature page. You must have a business plan to use this feature. (optional)
       # @option opts [Array<String>] cc_email_addresses The email addresses that should be CCed.
+      # @option opts [Array<Hash>] custom_fields An array of custom merge fields, representing those present on the document with Text Tags.
       #
       # @return [HelloSign::Resource::UnclaimedDraft] a UnclaimedDraft object
       #
@@ -147,6 +151,8 @@ module HelloSign
       def create_embedded_unclaimed_draft(opts)
         opts[:client_id] ||= self.client_id
         prepare_files opts
+        prepare_custom_fields opts
+        
         if opts[:type] == 'request_signature' || opts[:type] == 'send_document'
           prepare_signers opts
         end

--- a/lib/hello_sign/version.rb
+++ b/lib/hello_sign/version.rb
@@ -23,5 +23,5 @@
 #
 
 module HelloSign
-  VERSION = '3.6.3'
+  VERSION = '3.6.4'
 end


### PR DESCRIPTION
Allow custom_fields for signature requests/unclaimed drafts using an endpoint
This parameter is needed since the feature was added to merge data into text tags