### PR TITLE
Preserve original filename on UploadedFiles

### DIFF
--- a/lib/hello_sign/client.rb
+++ b/lib/hello_sign/client.rb
@@ -236,7 +236,7 @@ module HelloSign
           elsif defined? ActionDispatch::Http::UploadedFile
             if file.is_a? ActionDispatch::Http::UploadedFile
               mime_type = MIMEfromIO file
-              opts[:"file[#{index}]"] = UploadIO.new(file.tempfile, mime_type)
+              opts[:"file[#{index}]"] = UploadIO.new(file.tempfile, mime_type, file.original_filename)
             end
           else
             raise HelloSign::Error::NotSupportedType.new "#{file.class} is not a supported. Must be a string or ActionDispatch::Http::UploadedFile"


### PR DESCRIPTION
We have the original file name for uploaded files, so this commit changes uploading to pass this information to the API for better metadata. Without this change, files show up as `RackMultipart20180907-5692-1217313.pdf` for example. :sweat_smile: 