### PR TITLE
Allow files to be StringIO objects

### DIFF
--- a/lib/hello_sign/client.rb
+++ b/lib/hello_sign/client.rb
@@ -226,6 +226,8 @@ module HelloSign
           elsif file.is_a? File
             mime_type = MIMEfromIO file
             opts[:"file[#{index}]"] = Faraday::UploadIO.new(file, mime_type)
+          elsif file.is_a? StringIO
+            opts[:"file[#{index}]"] = Faraday::UploadIO.new(file, 'application/pdf')
           elsif defined? ActionDispatch::Http::UploadedFile
             if file.is_a? ActionDispatch::Http::UploadedFile
               mime_type = MIMEfromIO file


### PR DESCRIPTION
The purpose of this change is to allow files to be in memory IO objects. This is useful when file contents are stored in a database and need to be passed to the hello sign client.