### PR TITLE
Fixes for client_id with signature requests

### DIFF
--- a/lib/hello_sign/api/signature_request.rb
+++ b/lib/hello_sign/api/signature_request.rb
@@ -103,11 +103,12 @@ module HelloSign
       #   signature_request = @client.send_signature_request(
       #     test_mode: 1,
       #     allow_decline: 1,
+      #     client_id: 'b6b8e7deaf8f0b95c029dca049356d4a2cf9710a',
       #     title: 'NDA with Acme Co.',
       #     subject: 'The NDA we talked about',
       #     message: 'Please sign this NDA and then we can discuss more. Let me know if you have any questions.',
       #     metadata: {
-      #       client_id: '1234',
+      #       client_name: 'John Doe',
       #       custom_text: 'NDA #9'
       #     },
       #     signers: [{
@@ -168,6 +169,7 @@ module HelloSign
       #       }
       #     )
       def send_signature_request(opts)
+        opts[:client_id] ||= self.client_id
         prepare_files opts
         prepare_signers opts
         prepare_form_fields opts
@@ -211,13 +213,14 @@ module HelloSign
       #   signature_request = @client.send_signature_request_with_template(
       #     test_mode: 1,
       #     allow_decline: 0,
+      #     client_id: 'b6b8e7deaf8f0b95c029dca049356d4a2cf9710a',
       #     template_id: 'c26b8a16784a872da37ea946b9ddec7c1e11dff6',
       #     title: 'Purchase Order',
       #     subject: 'Purchase Order',
       #     message: 'Glad we could come to an agreement.',
       #     files: ['NDA.pdf', 'AppendixA.pdf'],
       #     metadata: {
-      #       client_id: '1234',
+      #       client_name: 'John Doe',
       #       custom_text: 'NDA #9'
       #     },
       #     signers: [
@@ -247,6 +250,7 @@ module HelloSign
       #      }
       #   )
       def send_signature_request_with_template(opts)
+        opts[:client_id] ||= self.client_id
         prepare_signers opts
         prepare_ccs opts
         prepare_templates opts
@@ -283,12 +287,13 @@ module HelloSign
       #   signature_request = @client.bulk_send_with_template(
       #     test_mode: 1,
       #     allow_decline: 0,
+      #     client_id: 'b6b8e7deaf8f0b95c029dca049356d4a2cf9710a',
       #     template_id: 'c26b8a16784a872da37ea946b9ddec7c1e11dff6',
       #     title: 'Purchase Order',
       #     subject: 'Purchase Order',
       #     message: 'Glad we could come to an agreement.',
       #     metadata: {
-      #       client_id: '1234',
+      #       client_name: 'John Doe',
       #       custom_text: 'NDA #9'
       #     },
       #     signer_list: [
@@ -320,6 +325,7 @@ module HelloSign
       #     ]
       #   )
       def bulk_send_with_template(opts)
+        opts[:client_id] ||= self.client_id
         prepare_bulk_signers opts
         prepare_ccs opts
         prepare_templates opts
@@ -362,7 +368,7 @@ module HelloSign
       #     subject: 'Purchase Order',
       #     message: 'Glad we could come to an agreement.',
       #     metadata: {
-      #       client_id: '1234',
+      #       client_name: 'John Doe',
       #       custom_text: 'NDA #9'
       #     },
       #     signer_list: [
@@ -394,6 +400,7 @@ module HelloSign
       #     ]
       #   )
       def embedded_bulk_send_with_template(opts)
+        opts[:client_id] ||= self.client_id
         prepare_bulk_signers opts
         prepare_ccs opts
         prepare_templates opts
@@ -511,7 +518,7 @@ module HelloSign
       #     subject: 'The NDA we talked about',
       #     message: 'Please sign this NDA and then we can discuss more. Let me know if you have any questions.',
       #     metadata: {
-      #       client_id: '1234',
+      #       client_name: 'John Doe',
       #       custom_text: 'NDA #9'
       #     },
       #     signers: [
@@ -600,7 +607,7 @@ module HelloSign
       #     message: 'Glad we could come to an agreement.',
       #     files: ['NDA.pdf', 'AppendixA.pdf'],
       #     metadata: {
-      #       client_id: '1234',
+      #       client_name: 'John Doe',
       #       custom_text: 'NDA #9'
       #     },
       #     signers: [


### PR DESCRIPTION
In the code that creates signature requests, there are some bugs related to the `client_id` parameter that I'm hoping to address.

First, through the [configuration](https://github.com/HelloFax/hellosign-ruby-sdk/blob/v3/lib/hello_sign/configuration.rb) there is an [option](https://github.com/HelloFax/hellosign-ruby-sdk/blob/v3/lib/hello_sign/configuration.rb#L61) to supply a client_id like this:

```
HelloSign.configure do |config|
  config.api_key = 'FOO'
  config.client_id = 'BAR'
end
```

But unfortunately that client_id is only used in some of the request types. Lines like this appear at the top of the two methods for creating embedded signature requests but not in the others:

```
opts[:client_id] ||= self.client_id
```

I have added this to all of the methods that create signature requests. It should probably be applied in other places throughout this library, but the signature requests are the only part of it that I'm working with and I'm hesitant to try to change more.

Second, the documentation for these signature request methods do not always indicate that you can even pass a client_id, which they should. I added this to three of the methods where it was missing.

Finally, in the documentation for all of the signature request methods the metadata field includes a client_id parameter. This is confusing because it makes it seem like we need to pass the client_id in multiple places or might lead people to trying to pass theirs in the metadata. Since the metadata can accept any keys, I changed this to client_name in all of the places where it appeared.

There is one failing test, but I validated that it also failed prior to these changes.