### PR TITLE
Make faraday 2.2 work properly

### DIFF
--- a/hellosign-ruby-sdk.gemspec
+++ b/hellosign-ruby-sdk.gemspec
@@ -47,7 +47,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'webmock'
-  spec.add_runtime_dependency 'faraday'
+  spec.add_runtime_dependency 'faraday', '~> 2.2.0'
+  spec.add_runtime_dependency 'faraday-multipart', '~> 1.0.0'
   spec.add_runtime_dependency 'multi_json'
   spec.add_runtime_dependency 'mime-types'
 end

--- a/lib/hello_sign/client.rb
+++ b/lib/hello_sign/client.rb
@@ -21,6 +21,7 @@
 # SOFTWARE.
 
 require 'faraday'
+require 'faraday/multipart'
 require 'multi_json'
 require 'mime/types'
 require 'hello_sign/error'


### PR DESCRIPTION
The gem is not specifying a faraday version, but it doesn't work with faraday 2.0. 🤦🏻  This makes it work with that version and then specifies it as the required one in the specfile.