### PR TITLE
fix `ArgumentError` in `HelloSign::Resource::BaseResource`

### DIFF
--- a/lib/hello_sign/resource/base_resource.rb
+++ b/lib/hello_sign/resource/base_resource.rb
@@ -66,8 +66,10 @@ module HelloSign
       #   resource.email_address => "me@example.com"
       #   resource.not_in_hash_keys => nil
       def method_missing(method)
-        @data.key?(method.to_s) ? @data[method.to_s] : nil
+        # method_name could be `[]` and the first arg is the key
+        @data[method_name.to_s].presence || @data[args.try(:first)].presence
       end
+
     end
   end
 end


### PR DESCRIPTION
how to reproduce:
1. create a template which contains field group
2. `template = HelloSign::Client.new.get_template template_id: insert_template_id_here`
3. `template.documents[0].field_groups[0].data['rule']['groupLabel']`

"ArgumentError: wrong number of arguments (given 2, expected 1)" will be raised